### PR TITLE
Handle MySQL TEXT types of 'tiny', 'medium', and 'long'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,15 +43,21 @@ let property = attribute => {
     || type instanceof Sequelize.DATEONLY
     || type instanceof Sequelize.TIME) {
 
-    const schema = {
-      type: 'string'
-    };
+    const schema = {type: 'string'};
 
-    if (type.options && type.options.length) {
-      schema.maxLength = type.options.length;
-    } else {
-      schema.maxLength = type._length;
+    var maxLength = (type.options && type.options.length) || type._length;
+
+    if (type instanceof Sequelize.TEXT) {
+      // Handle 'tiny', 'medium', and 'long' allowed for MySQL
+      switch (maxLength) {
+        case 'tiny': maxLength = 255; break;
+        case 'medium': maxLength = 16777215; break;
+        case 'long': maxLength = 4294967295; break;
+      }
+
     }
+
+    if (maxLength) schema.maxLength = maxLength;
 
     return schema;
   }

--- a/test/spec.js
+++ b/test/spec.js
@@ -106,6 +106,9 @@ describe('sequelize-json-schema', () => {
     it('should specify string length', () => {
       let Simple = sequelize.define('simple', {
         title: Sequelize.STRING,
+        tinyTitle: Sequelize.TEXT('tiny'),
+        mediumTitle: Sequelize.TEXT('medium'),
+        longTitle: Sequelize.TEXT('long'),
         password: {
           type: Sequelize.STRING(100)
         },
@@ -116,6 +119,12 @@ describe('sequelize-json-schema', () => {
 
       expect(def.properties.title).to.exist;
       expect(def.properties.title.maxLength).to.equal(255);
+      expect(def.properties.tinyTitle).to.exist;
+      expect(def.properties.tinyTitle.maxLength).to.equal(255);
+      expect(def.properties.mediumTitle).to.exist;
+      expect(def.properties.mediumTitle.maxLength).to.equal(16777215);
+      expect(def.properties.longTitle).to.exist;
+      expect(def.properties.longTitle.maxLength).to.equal(4294967295);
       expect(def.properties.password).to.exist;
       expect(def.properties.password.maxLength).to.equal(100);
       expect(def.properties.secret).to.exist;


### PR DESCRIPTION
Sequelize supports these types for the corresponding MySQL types, here: https://github.com/sequelize/sequelize/blob/3e5b8772ef75169685fc96024366bca9958fee63/lib/data-types.js#L180-L191

... so map them to the max lengths defined by MySQL: http://dev.mysql.com/doc/refman/5.7/en/string-type-overview.html