### PR TITLE
Adding support for null type with option allowNull

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-json-schema",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Use your Sequelize models in JSON Schemas or Swagger",
   "keywords": [
     "sequelize",

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ module.exports = (model, options) => {
 
     if (attribute) {
       schema.properties[attributeName] = property(attribute, options);
-      if (false === attribute.allowNull || options.allowNull) {
+      if (false === attribute.allowNull || options.alwaysRequired) {
         schema.required.push(attributeName);
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -8,31 +8,33 @@ let enumProperty = attribute => {
     }
 }
 
-let property = attribute => {
+let property = (attribute, options) => {
   let type = attribute.type;
 
+  let addNull = attribute.allowNull && options.allowNull
+
   if (type instanceof Sequelize.ENUM) return enumProperty(attribute);
-  if (type instanceof Sequelize.BOOLEAN) return { type: 'boolean' };
-  if (type instanceof Sequelize.INTEGER) return { type: 'integer', format: 'int32' };
-  if (type instanceof Sequelize.BIGINT) return { type: 'integer', format: 'int64' };
+  if (type instanceof Sequelize.BOOLEAN) return { type: addNull ? ['boolean', 'null'] : 'boolean' };
+  if (type instanceof Sequelize.INTEGER) return { type: addNull ? ['integer', 'null'] : 'integer', format: 'int32' };
+  if (type instanceof Sequelize.BIGINT) return { type: addNull ? ['integer', 'null'] : 'integer', format: 'int64' };
 
   if (type instanceof Sequelize.FLOAT
     || type instanceof Sequelize.REAL) {
-    return { type: 'number', format: 'float' };
+    return { type: addNull ? ['number', 'null'] : 'number', format: 'float' };
   }
 
-  if (type instanceof Sequelize.DOUBLE) { return { type: 'number', format: 'double' }; }
+  if (type instanceof Sequelize.DOUBLE) { return { type: addNull ? ['number', 'null'] : 'number', format: 'double' }; }
 
-  if (type instanceof Sequelize.DECIMAL) { return { type: 'number' }; }
+  if (type instanceof Sequelize.DECIMAL) { return { type: addNull ? ['number', 'null'] : 'number' }; }
 
-  if (type instanceof Sequelize.DATEONLY) { return { type: 'string', format: 'date' }; }
-  if (type instanceof Sequelize.DATE) { return { type: 'string', format: 'date-time' }; }
-  if (type instanceof Sequelize.TIME) { return { type: 'string' }; }
+  if (type instanceof Sequelize.DATEONLY) { return { type: addNull ? ['string', 'null'] : 'string', format: 'date' }; }
+  if (type instanceof Sequelize.DATE) { return { type: addNull ? ['string', 'null'] : 'string', format: 'date-time' }; }
+  if (type instanceof Sequelize.TIME) { return { type: addNull ? ['string', 'null'] : 'string'}; }
 
   if (type instanceof Sequelize.UUID
     || type instanceof Sequelize.UUIDV1
     || type instanceof Sequelize.UUIDV4) {
-    return { type: 'string', format: 'uuid' };
+    return { type: addNull ? ['string', 'null'] : 'string', format: 'uuid' };
   }
 
   if (type instanceof Sequelize.CHAR
@@ -43,7 +45,7 @@ let property = attribute => {
     || type instanceof Sequelize.DATEONLY
     || type instanceof Sequelize.TIME) {
 
-    const schema = {type: 'string'};
+    const schema = {type: addNull ? ['string', 'null'] : 'string'};
 
     var maxLength = (type.options && type.options.length) || type._length;
 
@@ -68,7 +70,7 @@ let property = attribute => {
   }
 
   if (type instanceof Sequelize.VIRTUAL) {
-    return type.returnType ? property({ type: type.returnType }) : { type: 'string' };
+    return type.returnType ? property({ type: type.returnType, allowNull: type.allowNull }, options) : { type: addNull ? ['string', 'null'] : 'string'};
   }
 
   // Need suport for the following
@@ -113,8 +115,8 @@ module.exports = (model, options) => {
     let attribute = model.rawAttributes[attributeName];
 
     if (attribute) {
-      schema.properties[attributeName] = property(attribute);
-      if (false === attribute.allowNull) {
+      schema.properties[attributeName] = property(attribute, options);
+      if (false === attribute.allowNull || options.allowNull) {
         schema.required.push(attributeName);
       }
     }

--- a/test/spec.js
+++ b/test/spec.js
@@ -103,7 +103,7 @@ describe('sequelize-json-schema', () => {
       expect(def.properties.secret).to.exist;
     });
 
-    it('should add required for all if option allowNull turned on', () => {
+    it('should add null type if option allowNull turned on', () => {
        let Simple = sequelize.define('simple', {
         title: Sequelize.STRING,
         password: {
@@ -114,6 +114,31 @@ describe('sequelize-json-schema', () => {
 
       let def = definition(Simple, {
         allowNull: true
+      });
+
+      expect(def.properties.title).to.exist;
+      expect(def.required).to.be.an('array');
+      expect(def.required).to.contain('id');
+      expect(def.required).to.contain('createdAt');
+      expect(def.required).to.contain('updatedAt');
+      expect(def.required).not.to.contain('title');
+      expect(def.required).not.to.contain('password');
+      expect(def.properties.password.type).to.eql(['string', 'null'])
+      expect(def.properties.title.type).to.eql('string')
+    })
+
+    it('should add to required if option allowNull and alwaysRequired turned on', () => {
+       let Simple = sequelize.define('simple', {
+        title: Sequelize.STRING,
+        password: {
+          allowNull: true,
+          type: Sequelize.STRING
+        }
+      });
+
+      let def = definition(Simple, {
+        allowNull: true,
+        alwaysRequired: true
       });
 
       expect(def.properties.title).to.exist;

--- a/test/spec.js
+++ b/test/spec.js
@@ -103,6 +103,30 @@ describe('sequelize-json-schema', () => {
       expect(def.properties.secret).to.exist;
     });
 
+    it('should add required for all if option allowNull turned on', () => {
+       let Simple = sequelize.define('simple', {
+        title: Sequelize.STRING,
+        password: {
+          allowNull: true,
+          type: Sequelize.STRING
+        }
+      });
+
+      let def = definition(Simple, {
+        allowNull: true
+      });
+
+      expect(def.properties.title).to.exist;
+      expect(def.required).to.be.an('array');
+      expect(def.required).to.contain('id');
+      expect(def.required).to.contain('createdAt');
+      expect(def.required).to.contain('updatedAt');
+      expect(def.required).to.contain('title');
+      expect(def.required).to.contain('password');
+      expect(def.properties.password.type).to.eql(['string', 'null'])
+      expect(def.properties.title.type).to.eql('string')
+    })
+
     it('should specify string length', () => {
       let Simple = sequelize.define('simple', {
         title: Sequelize.STRING,


### PR DESCRIPTION
Resolves https://github.com/chaliy/sequelize-json-schema/issues/11

Placed it behind an option for now to be backwards compatible. In my opinion it should be like this by default though. Thoughts?